### PR TITLE
Child theme CSS

### DIFF
--- a/wp-content/themes/justwrite_child/functions.php
+++ b/wp-content/themes/justwrite_child/functions.php
@@ -1,11 +1,17 @@
-<?php 
+<?php
 
+// Add parent stylesheet as dependency
+add_action( 'wp_enqueue_scripts', 'theme_enqueue_styles' );
+function theme_enqueue_styles() {
+    wp_enqueue_style( 'parent-style', get_template_directory_uri() . '/style.css' );
+
+}
 
 // Function for creating Widegets
 function create_widget($name, $id, $description) {
- 
+
     register_sidebar(array(
-        'name' => __( $name ),    
+        'name' => __( $name ),
         'id' => $id,
         'description' => __( $description ),
         'before_widget' => '<aside id="'.$id.'" class="widget %1$s %2$s">',
@@ -13,9 +19,9 @@ function create_widget($name, $id, $description) {
         'before_title' => '<h3>',
         'after_title' => '</h3>'
     ));
- 
+
 }
- 
+
 // Create the actual widgets
 create_widget("Footer Widget", "footer-widget-2", "Displays in the footer of the site, below the copyright");
 

--- a/wp-content/themes/justwrite_child/style.css
+++ b/wp-content/themes/justwrite_child/style.css
@@ -3,12 +3,13 @@ Theme Name: JustWrite Child
 Theme URI: http://www.acosmin.com/
 Description: Child theme for the JustWrite theme
 Author: Alexandru Cosmin
+Modified by: UPIR Core Team
 Author URI: http://wp.zacgordon.com/
 Template: justwrite
 Version: 1.0
+License: GNU General Public License v2.0
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
 */
-
-@import "../justwrite/style.css";
 
 #footer-widget-2 {
 	clear: both;


### PR DESCRIPTION
Remove the [import](https://github.com/infoeducatie/gazeta/blob/master/wp-content/themes/justwrite_child/style.css) and respect the Wordpress [standard](https://codex.wordpress.org/Child_Themes).
